### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Live Photo Demo
+# Live Photo Demo
 
 This is a quick example of how to take Apple's Live Photos without having an iPhone 6s or iPhone 6s Plus.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
